### PR TITLE
Like crud

### DIFF
--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/controller/CommentController.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/controller/CommentController.java
@@ -1,0 +1,44 @@
+package zerobase.group2.cookingRecipe.comment.controller;
+
+import java.security.Principal;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import zerobase.group2.cookingRecipe.comment.dto.CommentInput;
+import zerobase.group2.cookingRecipe.comment.service.CommentService;
+import zerobase.group2.cookingRecipe.common.model.ResponseResult;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseResult writeComment(Principal principal,
+        @RequestBody @Valid CommentInput.Write input) {
+        return ResponseResult.ok(commentService.writeComment(principal.getName(),
+            input.getRecipeId(), input.getText()));
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseResult updateComment(Principal principal,
+        @RequestBody @Valid CommentInput.Update input) {
+        return ResponseResult.ok(
+            commentService.updateComment(principal.getName(), input.getCommentId(),
+                input.getText()));
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseResult deleteComment(Principal principal,
+        @RequestBody @Valid CommentInput.Delete input) {
+        return ResponseResult.ok(commentService.deleteComment(principal.getName(),
+            input.getCommentId()));
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/controller/CommentController.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/controller/CommentController.java
@@ -15,7 +15,7 @@ import zerobase.group2.cookingRecipe.common.model.ResponseResult;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/comment")
+@RequestMapping("/comments")
 public class CommentController {
 
     private final CommentService commentService;

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/dto/CommentDto.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/dto/CommentDto.java
@@ -1,0 +1,32 @@
+package zerobase.group2.cookingRecipe.comment.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import zerobase.group2.cookingRecipe.comment.entity.Comment;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentDto {
+    private String memberEmail;
+    private String recipeTitle;
+    private String text;
+    private LocalDateTime createdAt;
+    private LocalDateTime updateAt;
+
+    public static CommentDto from(Comment comment){
+        return CommentDto.builder()
+            .memberEmail(comment.getMember().getEmail())
+            .recipeTitle(comment.getRecipe().getTitle())
+            .text(comment.getText())
+            .createdAt(comment.getCreatedAt())
+            .updateAt(comment.getUpdateAt())
+            .build();
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/dto/CommentInput.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/dto/CommentInput.java
@@ -1,0 +1,42 @@
+package zerobase.group2.cookingRecipe.comment.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+
+public class CommentInput {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Write {
+        @NotBlank
+        private String recipeId;
+        @NotBlank
+        @Length(max = 500)
+        private String text;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Update {
+        @NotNull
+        private long commentId;
+        @NotBlank
+        @Length(max = 500)
+        private String text;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Delete {
+        @NotNull
+        private long commentId;
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/entity/Comment.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/entity/Comment.java
@@ -1,0 +1,53 @@
+package zerobase.group2.cookingRecipe.comment.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_email", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id", nullable = false)
+    private Recipe recipe;
+
+    @Column(length = 500)
+    private String text;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/repository/CommentRepository.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package zerobase.group2.cookingRecipe.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zerobase.group2.cookingRecipe.comment.entity.Comment;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/service/CommentService.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/service/CommentService.java
@@ -36,8 +36,10 @@ public class CommentService {
     }
 
     public CommentDto updateComment(String email, long commentId, String text) {
-        getMemberById(email);
+        Member member = getMemberById(email);
         Comment comment = getCommentById(commentId);
+
+        validateCommentEditor(member, comment.getMember());
 
         comment.setText(text);
 
@@ -51,6 +53,12 @@ public class CommentService {
         commentRepository.delete(comment);
 
         return CommentDto.from(comment);
+    }
+
+    private void validateCommentEditor(Member member, Member commentWriter) {
+        if(!member.getEmail().equals(commentWriter.getEmail())){
+            throw new CustomException(ErrorCode.USER_NOT_EDITOR);
+        }
     }
 
     private Comment getCommentById(long commentId) {

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/service/CommentService.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/comment/service/CommentService.java
@@ -1,0 +1,70 @@
+package zerobase.group2.cookingRecipe.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import zerobase.group2.cookingRecipe.comment.dto.CommentDto;
+import zerobase.group2.cookingRecipe.comment.entity.Comment;
+import zerobase.group2.cookingRecipe.comment.repository.CommentRepository;
+import zerobase.group2.cookingRecipe.common.exception.CustomException;
+import zerobase.group2.cookingRecipe.common.type.ErrorCode;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.repository.MemberRepository;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+import zerobase.group2.cookingRecipe.recipe.repository.RecipeRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final RecipeRepository recipeRepository;
+
+    public CommentDto writeComment(String email, String recipeId, String text) {
+        Member member = getMemberById(email);
+        Recipe recipe = getRecipeById(recipeId);
+
+        return CommentDto.from(commentRepository.save(
+            Comment.builder()
+                .member(member)
+                .recipe(recipe)
+                .text(text)
+                .build()
+        ));
+    }
+
+    public CommentDto updateComment(String email, long commentId, String text) {
+        getMemberById(email);
+        Comment comment = getCommentById(commentId);
+
+        comment.setText(text);
+
+        return CommentDto.from(commentRepository.save(comment));
+    }
+
+    public CommentDto deleteComment(String email, long commentId) {
+        getMemberById(email);
+        Comment comment = getCommentById(commentId);
+
+        commentRepository.delete(comment);
+
+        return CommentDto.from(comment);
+    }
+
+    private Comment getCommentById(long commentId) {
+        return commentRepository.findById(commentId)
+            .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    private Member getMemberById(String email) {
+        return memberRepository.findById(email)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Recipe getRecipeById(String recipeId) {
+        return recipeRepository.findById(recipeId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/common/type/ErrorCode.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/common/type/ErrorCode.java
@@ -11,7 +11,11 @@ public enum ErrorCode {
     DATA_NOT_VALID("올바르지 않은 정보입니다."),
     ACCESS_NOT_VALID("올바르지 않은 접근입니다."),
     RECIPE_NOT_FOUND("레시피 정보가 존재하지 않습니다."),
-    USER_NOT_EDITOR("편집 관한이 없습니다.")
+    USER_NOT_EDITOR("편집 관한이 없습니다."),
+    RECIPE_ALREADY_LIKED("이미 좋아요를 한 레시피입니다."),
+    RECIPE_NOT_LIKED("좋아요를 하지 않은 레시피입니다."),
+    COMMENT_NOT_FOUND("댓글 정보가 존재하지 않습니다."),
+    RATING_NOT_FOUND("평점 정보가 존재하지 않습니다.")
 ;
     private final String description;
 }

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/config/SecurityConfig.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.headers().frameOptions().sameOrigin();
 
         http.authorizeRequests()
-            .antMatchers("/",
+            .antMatchers("/**",
                 "/member/register",
                 "/member/email-auth",
                 "/member/find-password",

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/controller/LikeController.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/controller/LikeController.java
@@ -1,0 +1,31 @@
+package zerobase.group2.cookingRecipe.like.controller;
+
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import zerobase.group2.cookingRecipe.common.model.ResponseResult;
+import zerobase.group2.cookingRecipe.like.service.LikeService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/like")
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/{recipeId}")
+    public ResponseResult likeRecipe(@PathVariable String recipeId,
+        Principal principal){
+        return ResponseResult.ok(likeService.likeRecipe(recipeId, principal.getName()));
+    }
+
+    @DeleteMapping("/{recipeId}")
+    public ResponseResult dislikeRecipe(@PathVariable String recipeId,
+        Principal principal){
+        return ResponseResult.ok(likeService.dislikeRecipe(recipeId, principal.getName()));
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/dto/LikeDto.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/dto/LikeDto.java
@@ -1,0 +1,25 @@
+package zerobase.group2.cookingRecipe.like.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import zerobase.group2.cookingRecipe.like.entity.LikeEntity;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LikeDto {
+    private String memberEmail;
+    private String recipeTitle;
+
+    public static LikeDto from(LikeEntity like){
+        return LikeDto.builder()
+            .memberEmail(like.getMember().getEmail())
+            .recipeTitle(like.getRecipe().getTitle())
+            .build();
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/entity/LikeEntity.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/entity/LikeEntity.java
@@ -1,0 +1,45 @@
+package zerobase.group2.cookingRecipe.like.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.entity.MemberRecipeCompKey;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@IdClass(MemberRecipeCompKey.class)
+public class LikeEntity {
+    // like가 SQL의 예약어라 LikeEntity로 이름 변경
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_email", nullable = false)
+    private Member member;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id", nullable = false)
+    private Recipe recipe;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/repository/LikeRepository.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/repository/LikeRepository.java
@@ -1,0 +1,16 @@
+package zerobase.group2.cookingRecipe.like.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zerobase.group2.cookingRecipe.like.entity.LikeEntity;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.entity.MemberRecipeCompKey;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+
+@Repository
+public interface LikeRepository extends JpaRepository<LikeEntity, MemberRecipeCompKey> {
+    Optional<LikeEntity> findByMemberAndRecipe(Member member, Recipe recipe);
+
+    boolean existsByMemberAndRecipe(Member member, Recipe recipe);
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/service/LikeService.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/like/service/LikeService.java
@@ -1,0 +1,68 @@
+package zerobase.group2.cookingRecipe.like.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import zerobase.group2.cookingRecipe.common.exception.CustomException;
+import zerobase.group2.cookingRecipe.common.type.ErrorCode;
+import zerobase.group2.cookingRecipe.like.dto.LikeDto;
+import zerobase.group2.cookingRecipe.like.entity.LikeEntity;
+import zerobase.group2.cookingRecipe.like.repository.LikeRepository;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.repository.MemberRepository;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+import zerobase.group2.cookingRecipe.recipe.repository.RecipeRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final MemberRepository memberRepository;
+    private final RecipeRepository recipeRepository;
+
+    public LikeDto likeRecipe(String recipeId, String email) {
+
+        Member member = getMemberById(email);
+        Recipe recipe = getRecipeById(recipeId);
+
+        if(likeRepository.existsByMemberAndRecipe(member, recipe)){
+            throw new CustomException(ErrorCode.RECIPE_ALREADY_LIKED);
+        }
+
+        LikeEntity like = likeRepository.save(LikeEntity.builder()
+            .member(member)
+            .recipe(recipe)
+            .build());
+
+        recipe.setLikeCount(recipe.getLikeCount() + 1);
+        recipeRepository.save(recipe);
+
+        return LikeDto.from(like);
+    }
+
+    public LikeDto dislikeRecipe(String recipeId, String email) {
+        Member member = getMemberById(email);
+        Recipe recipe = getRecipeById(recipeId);
+
+        LikeEntity like = likeRepository.findByMemberAndRecipe(member, recipe)
+            .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_LIKED));
+
+        likeRepository.delete(like);
+
+        recipe.setLikeCount(recipe.getLikeCount() - 1);
+        recipeRepository.save(recipe);
+
+        return LikeDto.from(like);
+    }
+
+    private Member getMemberById(String email) {
+        return memberRepository.findById(email)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Recipe getRecipeById(String recipeId) {
+        return recipeRepository.findById(recipeId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/member/dto/MemberDto.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/member/dto/MemberDto.java
@@ -1,12 +1,16 @@
 package zerobase.group2.cookingRecipe.member.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import zerobase.group2.cookingRecipe.comment.entity.Comment;
+import zerobase.group2.cookingRecipe.like.entity.LikeEntity;
 import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.rating.Entity.Rating;
 
 @Getter
 @Setter
@@ -18,6 +22,9 @@ public class MemberDto {
     private String name;
     private LocalDateTime registeredAt;
     private LocalDateTime updatedAt;
+    private List<LikeEntity> likeEntityList;
+    private List<Comment> commentList;
+    private List<Rating> ratingList;
 
     public static MemberDto from(Member member){
         return MemberDto.builder()
@@ -25,6 +32,9 @@ public class MemberDto {
             .name(member.getName())
             .registeredAt(member.getRegisteredAt())
             .updatedAt(member.getUpdatedAt())
+            .likeEntityList(member.getLikeEntityList())
+            .commentList(member.getCommentList())
+            .ratingList(member.getRatingList())
             .build();
     }
 }

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/member/entity/Member.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/member/entity/Member.java
@@ -1,12 +1,16 @@
 package zerobase.group2.cookingRecipe.member.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +19,10 @@ import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import zerobase.group2.cookingRecipe.comment.entity.Comment;
+import zerobase.group2.cookingRecipe.like.entity.LikeEntity;
 import zerobase.group2.cookingRecipe.member.type.MemberStatus;
+import zerobase.group2.cookingRecipe.rating.Entity.Rating;
 
 @Getter
 @Setter
@@ -25,29 +32,48 @@ import zerobase.group2.cookingRecipe.member.type.MemberStatus;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Member {
+
     @Id
-    String email;
-    String password;
-    String name;
+    private String email;
+    private String password;
+    private String name;
 
     @Enumerated(EnumType.STRING)
-    MemberStatus status;
+    private MemberStatus status;
 
-    String emailAuthKey;
-    LocalDateTime emailAuthDue;
-    boolean emailAuthYn;
+    private String emailAuthKey;
+    private LocalDateTime emailAuthDue;
+    private boolean emailAuthYn;
 
-    String passwordResetKey;
-    LocalDateTime passwordResetDue;
+    private String passwordResetKey;
+    private LocalDateTime passwordResetDue;
 
-    boolean admin;
+    private boolean admin;
 
     @CreatedDate
-    LocalDateTime registeredAt;
+    private LocalDateTime registeredAt;
     @LastModifiedDate
-    LocalDateTime updatedAt;
+    private LocalDateTime updatedAt;
 
-    public boolean validatePassword(String pw){
+    @OneToMany(mappedBy = "member",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        fetch = FetchType.LAZY)
+    private List<LikeEntity> likeEntityList;
+
+    @OneToMany(mappedBy = "member",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        fetch = FetchType.LAZY)
+    private List<Comment> commentList;
+
+    @OneToMany(mappedBy = "member",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        fetch = FetchType.LAZY)
+    private List<Rating> ratingList;
+
+    public boolean validatePassword(String pw) {
         return !password.equals(pw);
     }
 

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/member/entity/MemberRecipeCompKey.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/member/entity/MemberRecipeCompKey.java
@@ -1,0 +1,14 @@
+package zerobase.group2.cookingRecipe.member.entity;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberRecipeCompKey implements Serializable {
+    private String member;
+    private String recipe;
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/Entity/Rating.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/Entity/Rating.java
@@ -1,0 +1,50 @@
+package zerobase.group2.cookingRecipe.rating.Entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.entity.MemberRecipeCompKey;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@IdClass(MemberRecipeCompKey.class)
+public class Rating {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_email", nullable = false)
+    private Member member;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id", nullable = false)
+    private Recipe recipe;
+
+    private int score;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/controller/RatingController.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/controller/RatingController.java
@@ -1,0 +1,36 @@
+package zerobase.group2.cookingRecipe.rating.controller;
+
+import java.security.Principal;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import zerobase.group2.cookingRecipe.common.model.ResponseResult;
+import zerobase.group2.cookingRecipe.rating.dto.RatingInput;
+import zerobase.group2.cookingRecipe.rating.service.RatingService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rating")
+public class RatingController {
+
+    private final RatingService ratingService;
+
+    @PostMapping
+    public ResponseResult rateRecipe(Principal principal,
+        @RequestBody @Valid RatingInput input) {
+        return ResponseResult.ok(
+            ratingService.rateRecipe(principal.getName(), input.getRecipeId(), input.getScore()));
+    }
+
+    @PutMapping
+    public ResponseResult updateRateRecipe(Principal principal,
+        @RequestBody @Valid RatingInput input) {
+        return ResponseResult.ok(
+            ratingService.updateRateRecipe(principal.getName(), input.getRecipeId(),
+                input.getScore()));
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/dto/RatingDto.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/dto/RatingDto.java
@@ -1,0 +1,27 @@
+package zerobase.group2.cookingRecipe.rating.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import zerobase.group2.cookingRecipe.rating.Entity.Rating;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RatingDto {
+    private String memberEmail;
+    private String recipeTitle;
+    private int score;
+
+    public static RatingDto from(Rating rating){
+        return RatingDto.builder()
+            .memberEmail(rating.getMember().getEmail())
+            .recipeTitle(rating.getRecipe().getTitle())
+            .score(rating.getScore())
+            .build();
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/dto/RatingInput.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/dto/RatingInput.java
@@ -1,0 +1,21 @@
+package zerobase.group2.cookingRecipe.rating.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RatingInput {
+
+    @NotBlank
+    private String recipeId;
+    @NotNull
+    @Size(min = 1, max = 5)
+    private int score;
+
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/repository/RatingRepository.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/repository/RatingRepository.java
@@ -1,0 +1,14 @@
+package zerobase.group2.cookingRecipe.rating.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.entity.MemberRecipeCompKey;
+import zerobase.group2.cookingRecipe.rating.Entity.Rating;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+
+@Repository
+public interface RatingRepository extends JpaRepository<Rating, MemberRecipeCompKey> {
+    Optional<Rating> findByMemberAndRecipe(Member member, Recipe recipe);
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/service/RatingService.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/rating/service/RatingService.java
@@ -1,0 +1,68 @@
+package zerobase.group2.cookingRecipe.rating.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import zerobase.group2.cookingRecipe.common.exception.CustomException;
+import zerobase.group2.cookingRecipe.common.type.ErrorCode;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.repository.MemberRepository;
+import zerobase.group2.cookingRecipe.rating.Entity.Rating;
+import zerobase.group2.cookingRecipe.rating.dto.RatingDto;
+import zerobase.group2.cookingRecipe.rating.repository.RatingRepository;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+import zerobase.group2.cookingRecipe.recipe.repository.RecipeRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RatingService {
+    private final RatingRepository ratingRepository;
+    private final MemberRepository memberRepository;
+    private final RecipeRepository recipeRepository;
+
+    public RatingDto rateRecipe(String email, String recipeId, int score) {
+        Member member = getMemberById(email);
+        Recipe recipe = getRecipeById(recipeId);
+
+        Rating rating = ratingRepository.save(Rating.builder()
+            .member(member)
+            .recipe(recipe)
+            .score(score)
+            .build()
+        );
+
+        recipe.setTotalScore(recipe.getTotalScore() + score);
+        recipe.setRatingCount(recipe.getRatingCount() + 1);
+        recipeRepository.save(recipe);
+
+        return RatingDto.from(rating);
+    }
+
+    public RatingDto updateRateRecipe(String email, String recipeId, int newScore) {
+        Member member = getMemberById(email);
+        Recipe recipe = getRecipeById(recipeId);
+
+        Rating rating = ratingRepository.findByMemberAndRecipe(member, recipe)
+            .orElseThrow(() -> new CustomException(ErrorCode.RATING_NOT_FOUND));
+
+        int oldScore = rating.getScore();
+        rating.setScore(newScore);
+        ratingRepository.save(rating);
+
+        recipe.setTotalScore(recipe.getTotalScore() - oldScore + newScore);
+        recipeRepository.save(recipe);
+
+        return RatingDto.from(rating);
+    }
+
+    private Member getMemberById(String email) {
+        return memberRepository.findById(email)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Recipe getRecipeById(String recipeId) {
+        return recipeRepository.findById(recipeId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
+    }
+}

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/recipe/Entity/Recipe.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/recipe/Entity/Recipe.java
@@ -56,6 +56,7 @@ public class Recipe {
     private List<String> manualImagePath;
 
     private RecipeStatus status;
+    private Long views;
 
     private String email;
 

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/recipe/Entity/Recipe.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/recipe/Entity/Recipe.java
@@ -3,11 +3,14 @@ package zerobase.group2.cookingRecipe.recipe.Entity;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +20,9 @@ import org.json.simple.JSONObject;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import zerobase.group2.cookingRecipe.comment.entity.Comment;
+import zerobase.group2.cookingRecipe.like.entity.LikeEntity;
+import zerobase.group2.cookingRecipe.rating.Entity.Rating;
 import zerobase.group2.cookingRecipe.recipe.converter.RecipeConverter;
 import zerobase.group2.cookingRecipe.recipe.type.RecipeStatus;
 
@@ -59,6 +65,27 @@ public class Recipe {
     private LocalDateTime updatedAt;
 
     private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "recipe",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        fetch = FetchType.LAZY)
+    private List<LikeEntity> likeEntityList;
+    private long likeCount;
+
+    @OneToMany(mappedBy = "recipe",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        fetch = FetchType.LAZY)
+    private List<Comment> commentList;
+
+    @OneToMany(mappedBy = "member",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        fetch = FetchType.LAZY)
+    private List<Rating> ratingList;
+    private long totalScore;
+    private long ratingCount;
 
     public static Recipe from(JSONObject jsonObject, List<String> manual, List<String> manualImagePath,
                                 String user){

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/recipe/controller/RecipeController.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/recipe/controller/RecipeController.java
@@ -1,6 +1,8 @@
 package zerobase.group2.cookingRecipe.recipe.controller;
 
 import java.security.Principal;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -42,8 +44,9 @@ public class RecipeController {
     }
 
     @GetMapping("/{recipeId}")
-    public ResponseResult readRecipe(@PathVariable String recipeId){
-        return ResponseResult.ok(recipeService.readRecipe(recipeId));
+    public ResponseResult readRecipe(@PathVariable String recipeId,
+        HttpServletRequest request, HttpServletResponse response){
+        return ResponseResult.ok(recipeService.readRecipe(recipeId, request.getCookies(), response));
     }
 
     @GetMapping("/edit/{recipeId}")

--- a/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/recipe/dto/RecipeDto.java
+++ b/cookingRecipe/src/main/java/zerobase/group2/cookingRecipe/recipe/dto/RecipeDto.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import zerobase.group2.cookingRecipe.comment.entity.Comment;
+import zerobase.group2.cookingRecipe.like.entity.LikeEntity;
+import zerobase.group2.cookingRecipe.rating.Entity.Rating;
 import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
 
 @Getter
@@ -27,7 +30,19 @@ public class RecipeDto {
     private List<String> manual;
     private List<String> manualImagePath;
 
+    private Long views;
+
     private String email;
+
+    private List<LikeEntity> likeEntityList;
+    private long likeCount;
+
+    private List<Comment> commentList;
+
+    private List<Rating> ratingList;
+    private long totalScore;
+    private long ratingCount;
+
     public static RecipeDto from(Recipe recipe){
         return RecipeDto.builder()
             .id(recipe.getId())
@@ -40,7 +55,13 @@ public class RecipeDto {
             .kcal(recipe.getKcal())
             .manual(recipe.getManual())
             .manualImagePath(recipe.getManualImagePath())
+            .views(recipe.getViews())
             .email(recipe.getEmail())
+            .likeEntityList(recipe.getLikeEntityList())
+            .likeCount(recipe.getLikeCount())
+            .ratingList(recipe.getRatingList())
+            .totalScore(recipe.getTotalScore())
+            .ratingCount(recipe.getRatingCount())
             .build();
     }
 }

--- a/cookingRecipe/src/test/http/LikeControllerTest.http
+++ b/cookingRecipe/src/test/http/LikeControllerTest.http
@@ -1,0 +1,5 @@
+###
+POST http://localhost:8080/like/00ef7274b31f4ddbad960ba5d0186666
+Content-Type: application/json
+
+###

--- a/cookingRecipe/src/test/http/MemberControllerTest.http
+++ b/cookingRecipe/src/test/http/MemberControllerTest.http
@@ -1,8 +1,3 @@
-#POST http://localhost:8080/member/register
-#Content-Type: application/x-www-form-urlencoded
-#
-#email=magi8520@gmail.com&password=1234&name=aa
-
 ###
 POST http://localhost:8080/member/register
 Content-Type: application/json

--- a/cookingRecipe/src/test/java/zerobase/group2/cookingRecipe/comment/service/CommentServiceTest.java
+++ b/cookingRecipe/src/test/java/zerobase/group2/cookingRecipe/comment/service/CommentServiceTest.java
@@ -1,0 +1,202 @@
+package zerobase.group2.cookingRecipe.comment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import zerobase.group2.cookingRecipe.comment.dto.CommentDto;
+import zerobase.group2.cookingRecipe.comment.entity.Comment;
+import zerobase.group2.cookingRecipe.comment.repository.CommentRepository;
+import zerobase.group2.cookingRecipe.common.exception.CustomException;
+import zerobase.group2.cookingRecipe.common.type.ErrorCode;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.repository.MemberRepository;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+import zerobase.group2.cookingRecipe.recipe.repository.RecipeRepository;
+import zerobase.group2.cookingRecipe.recipe.type.RecipeStatus;
+
+@ExtendWith(SpringExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    RecipeRepository recipeRepository;
+
+    @Mock
+    CommentRepository commentRepository;
+
+    @InjectMocks
+    CommentService commentService;
+
+    private Member member;
+    private Recipe recipe;
+    private Comment comment;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+            .email("group2@gmail.com")
+            .name("g2")
+            .build();
+        recipe = Recipe.builder()
+            .id(UUID.randomUUID().toString().replace("-", ""))
+            .title("recipe title")
+            .mainImagePathBig("bigImagePath")
+            .mainImagePathSmall("smallImagePath")
+            .type1("구이")
+            .type2("반찬")
+            .ingredients("삼겹살")
+            .kcal(300.0)
+            .manual(Arrays.asList("판을 달군다", "고기를 꺼낸다", "굽는다"))
+            .manualImagePath(Arrays.asList("manualImage1", "manualImage2", "manualImage3"))
+            .status(RecipeStatus.REGISTERED)
+            .email(member.getEmail())
+            .build();
+        comment = Comment.builder()
+            .member(member)
+            .recipe(recipe)
+            .text("text")
+            .build();
+    }
+
+    @Test
+    @DisplayName("댓글 작성 성공")
+    void success_writeComment() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.of(recipe));
+        given(commentRepository.save(any()))
+            .willReturn(comment);
+        ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+
+        //when
+        commentService.writeComment("email", "recipeId", "text");
+
+        //then
+        verify(commentRepository).save(captor.capture());
+        Comment captorValue = captor.getValue();
+        assertEquals(member.getEmail(), captorValue.getMember().getEmail());
+        assertEquals(recipe.getTitle(), captorValue.getRecipe().getTitle());
+        assertEquals(comment.getText(), captorValue.getText());
+    }
+
+    @Test
+    @DisplayName("댓글 작성 실패 - 존재하지 않는 회원")
+    void fail_writeComment_userNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            commentService.writeComment("email", "recipeId", "text"));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("댓글 작성 실패 - 존재하지 않는 레시피")
+    void fail_writeComment_recipeNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            commentService.writeComment("email", "recipeId", "text"));
+
+        //then
+        assertEquals(ErrorCode.RECIPE_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 성공")
+    void success_updateComment() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(commentRepository.findById(anyLong()))
+            .willReturn(Optional.of(comment));
+        comment.setText("text2");
+        given(commentRepository.save(any()))
+            .willReturn(comment);
+
+        //when
+        CommentDto dto = commentService.updateComment("email", 1, "text");
+
+        //then
+        assertEquals(member.getEmail(), dto.getMemberEmail());
+        assertEquals(recipe.getTitle(), dto.getRecipeTitle());
+        assertEquals(comment.getText(), dto.getText());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패 - 존재하지 않는 회원")
+    void fail_updateComment_userNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            commentService.updateComment("email", 1, "text"));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패 - 존재하지 않는 코멘트")
+    void fail_updateComment_commentNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(commentRepository.findById(anyLong()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            commentService.updateComment("email", 1, "text"));
+
+        //then
+        assertEquals(ErrorCode.COMMENT_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공")
+    void success_deleteComment() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(commentRepository.findById(anyLong()))
+            .willReturn(Optional.of(comment));
+
+        //when
+        commentService.deleteComment("email", 1);
+
+        //then
+        verify(commentRepository).delete(comment);
+    }
+}

--- a/cookingRecipe/src/test/java/zerobase/group2/cookingRecipe/like/service/LikeServiceTest.java
+++ b/cookingRecipe/src/test/java/zerobase/group2/cookingRecipe/like/service/LikeServiceTest.java
@@ -1,0 +1,221 @@
+package zerobase.group2.cookingRecipe.like.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import zerobase.group2.cookingRecipe.common.exception.CustomException;
+import zerobase.group2.cookingRecipe.common.type.ErrorCode;
+import zerobase.group2.cookingRecipe.like.entity.LikeEntity;
+import zerobase.group2.cookingRecipe.like.repository.LikeRepository;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.repository.MemberRepository;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+import zerobase.group2.cookingRecipe.recipe.repository.RecipeRepository;
+import zerobase.group2.cookingRecipe.recipe.type.RecipeStatus;
+
+@ExtendWith(SpringExtension.class)
+class LikeServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    RecipeRepository recipeRepository;
+
+    @Mock
+    LikeRepository likeRepository;
+
+    @InjectMocks
+    LikeService likeService;
+
+    private Member member;
+    private Recipe recipe;
+    private LikeEntity like;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+            .email("group2@gmail.com")
+            .name("g2")
+            .build();
+        recipe = Recipe.builder()
+            .id(UUID.randomUUID().toString().replace("-", ""))
+            .title("recipe title")
+            .mainImagePathBig("bigImagePath")
+            .mainImagePathSmall("smallImagePath")
+            .type1("구이")
+            .type2("반찬")
+            .ingredients("삼겹살")
+            .kcal(300.0)
+            .manual(Arrays.asList("판을 달군다", "고기를 꺼낸다", "굽는다"))
+            .manualImagePath(Arrays.asList("manualImage1", "manualImage2", "manualImage3"))
+            .status(RecipeStatus.REGISTERED)
+            .email(member.getEmail())
+            .likeCount(10)
+            .build();
+        like = LikeEntity.builder()
+            .member(member)
+            .recipe(recipe)
+            .build();
+    }
+
+    @Test
+    @DisplayName("좋아요 추가 성공")
+    void successLikeRecipe() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.of(recipe));
+        given(likeRepository.save(any()))
+            .willReturn(like);
+        ArgumentCaptor<LikeEntity> captor = ArgumentCaptor.forClass(LikeEntity.class);
+        ArgumentCaptor<Recipe> recipeCaptor = ArgumentCaptor.forClass(Recipe.class);
+
+        //when
+        likeService.likeRecipe("recipeId", "memberEmail");
+
+        //then
+        verify(likeRepository).save(captor.capture());
+        verify(recipeRepository).save(recipeCaptor.capture());
+        LikeEntity captorValue = captor.getValue();
+        assertEquals(member.getEmail(), captorValue.getMember().getEmail());
+        assertEquals(recipe.getTitle(), captorValue.getRecipe().getTitle());
+        assertEquals(11, captorValue.getRecipe().getLikeCount());
+        assertEquals(recipeCaptor.getValue().getLikeCount(), captorValue.getRecipe().getLikeCount());
+    }
+
+    @Test
+    @DisplayName("좋아요 추가 실패 - 존재하지 않는 회원")
+    void fail_likeRecipe_userNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            likeService.likeRecipe("recipeId", "memberEmail"));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("좋아요 추가 실패 - 존재하지 않는 레시피")
+    void fail_likeRecipe_recipeNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            likeService.likeRecipe("recipeId", "memberEmail"));
+
+        //then
+        assertEquals(ErrorCode.RECIPE_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("좋아요 추가 실패 - 이미 좋아요 한 레시피")
+    void fail_likeRecipe_recipeAlreadyLiked() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.of(recipe));
+        given(likeRepository.existsByMemberAndRecipe(any(), any()))
+            .willReturn(true);
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            likeService.likeRecipe("recipeId", "memberEmail"));
+
+        //then
+        assertEquals(ErrorCode.RECIPE_ALREADY_LIKED, exception.getError());
+    }
+
+    @Test
+    @DisplayName("좋아요 삭제 성공")
+    void success_dislikeRecipe() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.of(recipe));
+        given(likeRepository.findByMemberAndRecipe(any(), any()))
+            .willReturn(Optional.of(like));
+
+        //when
+        likeService.dislikeRecipe("recipeId", "memberEmail");
+
+        //then
+        verify(likeRepository).delete(like);
+        assertEquals(9, recipe.getLikeCount());
+        assertEquals(recipe.getLikeCount(), recipe.getLikeCount());
+    }
+
+    @Test
+    @DisplayName("좋아요 삭제 실패 - 존재하지 않는 회원")
+    void fail_dislikeRecipe_userNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            likeService.dislikeRecipe("recipeId", "memberEmail"));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("좋아요 삭제 실패 - 존재하지 않는 레시피")
+    void fail_dislikeRecipe_recipeNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            likeService.dislikeRecipe("recipeId", "memberEmail"));
+
+        //then
+        assertEquals(ErrorCode.RECIPE_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("좋아요 삭제 실패 - 좋아요 상태가 아닌 레시피")
+    void fail_dislikeRecipe_recipeNotLiked() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.of(recipe));
+        given(likeRepository.findByMemberAndRecipe(any(), any()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            likeService.dislikeRecipe("recipeId", "memberEmail"));
+
+        //then
+        assertEquals(ErrorCode.RECIPE_NOT_LIKED, exception.getError());
+    }
+}

--- a/cookingRecipe/src/test/java/zerobase/group2/cookingRecipe/rating/service/RatingServiceTest.java
+++ b/cookingRecipe/src/test/java/zerobase/group2/cookingRecipe/rating/service/RatingServiceTest.java
@@ -1,0 +1,214 @@
+package zerobase.group2.cookingRecipe.rating.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import zerobase.group2.cookingRecipe.common.exception.CustomException;
+import zerobase.group2.cookingRecipe.common.type.ErrorCode;
+import zerobase.group2.cookingRecipe.member.entity.Member;
+import zerobase.group2.cookingRecipe.member.repository.MemberRepository;
+import zerobase.group2.cookingRecipe.rating.Entity.Rating;
+import zerobase.group2.cookingRecipe.rating.repository.RatingRepository;
+import zerobase.group2.cookingRecipe.recipe.Entity.Recipe;
+import zerobase.group2.cookingRecipe.recipe.repository.RecipeRepository;
+import zerobase.group2.cookingRecipe.recipe.type.RecipeStatus;
+
+@ExtendWith(SpringExtension.class)
+class RatingServiceTest {
+
+    public static final int RATING_COUNT = 10;
+    public static final long TOTAL_SCORE = 100L;
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    RecipeRepository recipeRepository;
+
+    @Mock
+    RatingRepository ratingRepository;
+
+    @InjectMocks
+    RatingService ratingService;
+
+    private Member member;
+    private Recipe recipe;
+    private Rating rating;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+            .email("group2@gmail.com")
+            .name("g2")
+            .build();
+        recipe = Recipe.builder()
+            .id(UUID.randomUUID().toString().replace("-", ""))
+            .title("recipe title")
+            .mainImagePathBig("bigImagePath")
+            .mainImagePathSmall("smallImagePath")
+            .type1("구이")
+            .type2("반찬")
+            .ingredients("삼겹살")
+            .kcal(300.0)
+            .manual(Arrays.asList("판을 달군다", "고기를 꺼낸다", "굽는다"))
+            .manualImagePath(Arrays.asList("manualImage1", "manualImage2", "manualImage3"))
+            .status(RecipeStatus.REGISTERED)
+            .email(member.getEmail())
+            .totalScore(TOTAL_SCORE)
+            .ratingCount(RATING_COUNT)
+            .build();
+        rating = Rating.builder()
+            .member(member)
+            .recipe(recipe)
+            .score(5)
+            .build();
+    }
+
+    @Test
+    @DisplayName("평가 성공")
+    void success_rateRecipe() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.of(recipe));
+        given(ratingRepository.save(any()))
+            .willReturn(rating);
+        ArgumentCaptor<Rating> captor = ArgumentCaptor.forClass(Rating.class);
+
+        //when
+        ratingService.rateRecipe("email", "recipeId", rating.getScore());
+
+        //then
+        verify(ratingRepository).save(captor.capture());
+        Rating captorValue = captor.getValue();
+        assertEquals(member.getEmail(), captorValue.getMember().getEmail());
+        assertEquals(recipe.getTitle(), captorValue.getRecipe().getTitle());
+        assertEquals(rating.getScore(), captorValue.getScore());
+        assertEquals(TOTAL_SCORE + rating.getScore(), captorValue.getRecipe().getTotalScore());
+        assertEquals(RATING_COUNT + 1, captorValue.getRecipe().getRatingCount());
+    }
+
+    @Test
+    @DisplayName("레시피 평가 실패 - 존재하지 않는 회원")
+    void fail_rateRecipe_userNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            ratingService.rateRecipe("e", "r", 1));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("레시피 평가 실패 - 존재하지 않는 레시피")
+    void fail_rateRecipe_recipeNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            ratingService.rateRecipe("e", "r", 1));
+
+        //then
+        assertEquals(ErrorCode.RECIPE_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("평가 수정 성공")
+    void success_updateRateRecipe() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.of(recipe));
+        given(ratingRepository.findByMemberAndRecipe(any(), any()))
+            .willReturn(Optional.of(rating));
+        given(ratingRepository.save(any()))
+            .willReturn(rating);
+        ArgumentCaptor<Rating> captor = ArgumentCaptor.forClass(Rating.class);
+
+        //when
+        ratingService.updateRateRecipe("email", "recipeId", 1);
+
+        //then
+        verify(ratingRepository).save(captor.capture());
+        Rating captorValue = captor.getValue();
+        assertEquals(member.getEmail(), captorValue.getMember().getEmail());
+        assertEquals(recipe.getTitle(), captorValue.getRecipe().getTitle());
+        assertEquals(rating.getScore(), captorValue.getScore());
+        assertEquals(TOTAL_SCORE - 4, captorValue.getRecipe().getTotalScore());
+    }
+
+    @Test
+    @DisplayName("평가 수정 실패 - 존재하지 않는 회원")
+    void fail_updateRateRecipe_userNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            ratingService.updateRateRecipe("e", "r", 1));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("평가 수정 실패 - 존재하지 않는 레시피")
+    void fail_updateRateRecipe_recipeNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            ratingService.updateRateRecipe("e", "r", 1));
+
+        //then
+        assertEquals(ErrorCode.RECIPE_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    @DisplayName("평가 수정 실패 - 존재하지 않는 평가")
+    void fail_updateRateRecipe_ratingNotFound() {
+        //given
+        given(memberRepository.findById(anyString()))
+            .willReturn(Optional.of(member));
+        given(recipeRepository.findById(anyString()))
+            .willReturn(Optional.of(recipe));
+        given(ratingRepository.findByMemberAndRecipe(any(), any()))
+            .willReturn(Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            ratingService.updateRateRecipe("e", "r", 1));
+
+        //then
+        assertEquals(ErrorCode.RATING_NOT_FOUND, exception.getError());
+    }
+}


### PR DESCRIPTION
### PR 생성 날짜
* 2022/12/17

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
평점 추가/수정 추가
댓글 작성/수정/삭제 추가
좋아요 추가/삭제 추가
레시피 별 조회수 집계 추가 - 쿠키 참조해 레시피 별 24시간에 1회
추가 항목에 따라 회원/레시피 클래스에 관련 변수 추가.

**TO-BE**
레시피 검색/정렬
관리자 기능

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 

### 질문사항
Jpa의 OneToMany, ManyToOne을 사용해 연관관계 매핑을 했는데요. 따라서 회원 정보를 받아오면 자동으로 "내가 쓴 댓글", "내 좋아요 목록" 등이 함께 받아지는 형태가 되었습니다. 편하긴 했습니다만, 혹시 성능이 떨어지는 것은 아닌가 걱정이 드는데요. 혹시 이것보다 더 좋은 방법이 있을까요?

조회수 집계 중복 방지에 쿠키를 사용했습니다만, 쿠키가 조작이 쉽다보니 너무 허술한 건 아닌가 싶습니다. 그렇다고 DB에 조회데이터를 저장해 처리하자니 데이터의 중요성에 비해 서버의 부하나 저장소 공간 낭비 등이 마음에 걸립니다. 쿠키로 처리하는게 최선이 맞을까요?